### PR TITLE
changed query in find_matches depending on whether a initial match as…

### DIFF
--- a/db_where_app.rb
+++ b/db_where_app.rb
@@ -90,7 +90,7 @@ end
 
 get '/location_search' do
 
- 	stations_table = DB[:stations]
+	stations_table = DB[:stations]
 
   content_type :json
   query = params[:query]

--- a/models/observation.rb
+++ b/models/observation.rb
@@ -88,19 +88,19 @@ class Observation
 			time <= end_time}.exclude(
 			:station_id => station.id)
 
-		if wind_kph && humidity
-			initial_match_query.where(
-				:humidity => (humidity -5)..(humidity + 5)).where(
-				:wind_kph => (wind_kph -5)..(wind_kph + 5)).all
-		elsif wind_kph
-			initial_match_query.where(
-				:wind_kph => (wind_kph - 5)..(wind_kph + 5)).all
-		elsif humidity
-			initial_match_query.where(
-				:humidity => (humidity - 5)..(humidity + 5)).all
-		else
-			initial_match_query.all
+		query = initial_match_query
+
+		if wind_kph
+			query = query.where(
+				:wind_kph => (wind_kph - 5)..(wind_kph + 5))
 		end
+
+		if humidity
+			query = query.where(
+				:humidity => (humidity - 5)..(humidity + 5))
+		end
+
+		query.all
 
 	end
 


### PR DESCRIPTION
… neither humidity nor dewpoint, both, or just one of the two. humidity_score and wind_kph_score now give 0pts if a matching_observation is missing that value.
